### PR TITLE
Fix of bug when installing both twital and translation.

### DIFF
--- a/src/Goetas/TwitalBundle/Resources/config/jms-translation-bundle.xml
+++ b/src/Goetas/TwitalBundle/Resources/config/jms-translation-bundle.xml
@@ -4,8 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="twital.translation.extractor.jms.class">Goetas\TwitalBundle\Translation\Jms\TwitalExtractor
-        </parameter>
+        <parameter key="twital.translation.extractor.jms.class">Goetas\TwitalBundle\Translation\Jms\TwitalExtractor</parameter>
     </parameters>
 
     <services>

--- a/src/Goetas/TwitalBundle/Resources/config/jms-translation-bundle.xml
+++ b/src/Goetas/TwitalBundle/Resources/config/jms-translation-bundle.xml
@@ -10,6 +10,7 @@
     <services>
         <service id="twital.translation.extractor.jms" class="%twital.translation.extractor.jms.class%">
             <argument type="service" id="twig"/>
+            <argument type="service" id="jms_translation.file_source_factory" />
             <argument type="service" id="twital.loader"/>
             <tag name="jms_translation.file_visitor" alias="twital"/>
         </service>

--- a/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
+++ b/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
@@ -25,9 +25,9 @@ class TwitalExtractor extends TwigFileExtractor
      */
     private $twig;
 
-    public function __construct(\Twig_Environment $twig, TwitalLoader $twitalLoader)
-    {
-        parent::__construct($twig);
+	public function __construct(\Twig_Environment $twig, FileSourceFactory $fileSourceFactory, TwitalLoader $twitalLoader)
+	{
+		parent::__construct($twig, $fileSourceFactory);
         $this->twig = $twig;
         $this->twitalLoader = $twitalLoader;
     }

--- a/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
+++ b/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
@@ -5,6 +5,7 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor;
 use Goetas\Twital\TwitalLoader;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
+use Twig\Source;
 
 /**
  *
@@ -39,7 +40,7 @@ class TwitalExtractor extends TwigFileExtractor
 
             $source = $this->twitalLoader->getTwital()->compile($adapter, file_get_contents((string)$file));
 
-            $ast = $this->twig->parse($this->twig->tokenize($source, (string)$file));
+            $ast = $this->twig->parse($this->twig->tokenize(new Source($source, (string) $file)));
 
             $this->visitTwigFile($file, $catalogue, $ast);
         }

--- a/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
+++ b/src/Goetas/TwitalBundle/Translation/Jms/TwitalExtractor.php
@@ -4,6 +4,7 @@ namespace Goetas\TwitalBundle\Translation\Jms;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor;
 use Goetas\Twital\TwitalLoader;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 
 /**
  *


### PR DESCRIPTION
I am using twital bundle. Now I installed JMS Translation bundle and the application broke because of newline in classname, hich results in error: "'Goetas\\TwitalBundle\\Translation\\Jms\\TwitalExtractor
'" is not a valid class name for the "twital.translation.extractor.jms" service. (not the newline character). 
This should fix it.